### PR TITLE
security: Pin litellm to safe version 1.82.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "anthropic",
     "openai",
     "pydantic",
-    "litellm",
+    "litellm==1.82.6",  # Pin to safe version - DO NOT UPDATE - versions 1.82.7 and 1.82.8 compromised with malware
     "gradio",
     "loguru",
 ]


### PR DESCRIPTION
security: Pin litellm to safe version 1.82.6
 
- Pin litellm==1.82.6 to prevent installation of compromised versions 1.82.7 and 1.82.8
- Addresses TeamPCP supply chain attack with credential stealer malware
- Critical security fix - DO NOT UPDATE litellm until further notice